### PR TITLE
Gaby/trie2

### DIFF
--- a/cse.scm
+++ b/cse.scm
@@ -133,7 +133,12 @@ Authors: Gabrielle Ecanow, Marlena Gomez, Katherine Liew
 ;  (pp (> (length bindings) 0))
 
   (if (> (length bindings) 0) ; add repeated expression to library
-      (add-to-library (car (car bindings)) (car (cdr (car bindings))))
+      (begin (pp (car bindings))
+	     (pp (cadar bindings))
+	     (pp (caar bindings))
+	     (pp (list? (cadar bindings)))
+	     (add-to-library (intern (symbol->string (caar bindings))) 
+			     (cadar bindings)))
   )
 
   (if (null? bindings)
@@ -232,9 +237,9 @@ Authors: Gabrielle Ecanow, Marlena Gomez, Katherine Liew
 
 ;; test expr-1 added to library
 (find-in-library '(* x 3))
-("returned match-dict" (dict ($value expr-1 ?)))
-;Value: (#[uninterned-symbol 13 expr-1])
-
+; -> ((expr-10))
+(pp expr-10)
+; -> (lambda () (* x 3))
 
 (pp (gjs/cselim
      '(lambda (x)

--- a/cse.scm
+++ b/cse.scm
@@ -133,12 +133,8 @@ Authors: Gabrielle Ecanow, Marlena Gomez, Katherine Liew
 ;  (pp (> (length bindings) 0))
 
   (if (> (length bindings) 0) ; add repeated expression to library
-      (begin (pp (car bindings))
-	     (pp (cadar bindings))
-	     (pp (caar bindings))
-	     (pp (list? (cadar bindings)))
-	     (add-to-library (intern (symbol->string (caar bindings))) 
-			     (cadar bindings)))
+      (add-to-library (intern (symbol->string (caar bindings))) 
+		      (cadar bindings))
   )
 
   (if (null? bindings)
@@ -237,8 +233,8 @@ Authors: Gabrielle Ecanow, Marlena Gomez, Katherine Liew
 
 ;; test expr-1 added to library
 (find-in-library '(* x 3))
-; -> ((expr-10))
-(pp expr-10)
+; -> ((expr-13))
+(pp expr-13)
 ; -> (lambda () (* x 3))
 
 (pp (gjs/cselim

--- a/library-matcher.scm
+++ b/library-matcher.scm
@@ -38,6 +38,10 @@ Authors: Gabrielle Ecanow, Marlena Gomez, Katherine Liew
 
 ; ... testing ...
 
+(add-to-library 'expr-10 '(* x 3))
+(match-in-library '(* x 3))       ; -> (((* x 3) (expr-10)))
+(pp expr-10)                      ; -> (lambda () (* x 3))
+
 (add-to-library '1+2+3 '(+ 1 2 3))
 (match-in-library '(+ 1 2 3))                     ; -> (((+ 1 2 3) (|1+2+3|)))
 (match-in-library '(let ((x (+ 1 2 3))) (pp x)))  ; -> (((+ 1 2 3) (|1+2+3|)))


### PR DESCRIPTION
fixed cse issues with using uninterned symbols in the library